### PR TITLE
Fixed rotation support in IE7

### DIFF
--- a/jquery.iviewer.js
+++ b/jquery.iviewer.js
@@ -122,9 +122,18 @@ var ieTransforms = {
     },
     // this test is the inversion of the css filters test from the modernizr project
     useIeTransforms = function() {
-        var el = document.createElement('div');
-        el.style.cssText = ['-ms-','' ,''].join('filter:blur(2px); ');
-        return !!el.style.cssText && document.documentMode < 9;
+        var modElem = document.createElement('modernizr'),
+		mStyle = modElem.style,
+		omPrefixes = 'Webkit Moz O ms',
+		domPrefixes = omPrefixes.toLowerCase().split(' '),
+        	props = ("transform" + ' ' + domPrefixes.join("Transform ") + "Transform").split(' ');
+        for ( var i in props ) {
+            var prop = props[i];
+            if ( !contains(prop, "-") && mStyle[prop] !== undefined ) {
+                return false;
+            }
+        }
+        return true;
     }();
 
 $.widget( "ui.iviewer", $.ui.mouse, {


### PR DESCRIPTION
The already merged fix for #44 breaks support for IE7 and I was unable to get the original modernizr code that seems to be the base as there are no ie filter check (there is a css filter check but is for new CSS3 filter support), so I included the transform check, so if there is no transform support then we use the old ie filter.
