### PR TITLE
controls:removed controls as well on destroy and added method to handle show/hide of controls

### DIFF
--- a/jquery.iviewer.js
+++ b/jquery.iviewer.js
@@ -376,7 +376,7 @@ $.widget( "ui.iviewer", $.ui.mouse, {
         {
             this.createui();
         }
-
+        this.controls = this.container.find('.iviewer_common') || {};
         this._mouseInit();
     },
 
@@ -384,6 +384,8 @@ $.widget( "ui.iviewer", $.ui.mouse, {
         $.Widget.prototype.destroy.call( this );
         this._mouseDestroy();
         this.img_object.object().remove();
+        /*removing the controls on destroy*/
+        this.controls.remove();
         this.container.off('.iviewer');
         this.container.css('overflow', ''); //cleanup styles on destroy
     },
@@ -674,7 +676,18 @@ $.widget( "ui.iviewer", $.ui.mouse, {
 
         this.update_status();
     },
-
+    /**
+     * shows or hides the controls
+     * controls are shown/hidden based on user input
+     * @param Boolean flag that specifies whether to show or hide the controls
+     **/
+    showControls: function(flag) {
+        if(flag) {
+            this.controls.fadeIn();
+        } else {
+            this.controls.fadeOut();
+        }
+    },
     /**
     * changes zoom scale by delta
     * zoom is calculated by formula: zoom_base * zoom_delta^rate


### PR DESCRIPTION
1. Remove controls as well on widget destroy.
   Scenario: If you have 2 images, one(suppose A) has ui_disabled and other(suppose B) doesnt, and both are using the same viewer, if B is viewed and destroyed, and then A is viewed,  since B's ui was not destroyed, ui is shown for A even if ui is disbaled for A,
2. Added a method to control hide/show of controls
   Scenario: There may be cases where one doesnt want controls to be there all the time but only on some event trigger. ui_disabled just handles the initial configuration, hence the method
